### PR TITLE
Value Net

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,12 @@ FILES = $(shell find src -name '*.cpp')
 OBJS = $(FILES:.cpp=.o)
 
 OPTIMIZE ?= -O3 -flto
+EVALFILE ?= net.nnue 
 
 FLAGS = -std=c++20 -fconstexpr-steps=100000000
 FLAGS += $(EXTRA_FLAGS)
 FLAGS += $(OPTIMIZE)
+FLAGS += -DEVALFILE=\"$(EVALFILE)\" 
 
 CC ?= gcc
 CXX ?= g++

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ FILES = $(shell find src -name '*.cpp')
 OBJS = $(FILES:.cpp=.o)
 
 OPTIMIZE ?= -O3 -flto
-EVALFILE ?= net.nnue 
 
 FLAGS = -std=c++20 -fconstexpr-steps=100000000
 FLAGS += $(EXTRA_FLAGS)

--- a/src/chess/castle_rights.hpp
+++ b/src/chess/castle_rights.hpp
@@ -27,7 +27,7 @@ class CastleRights {
     [[nodiscard]] u8 to_mask() const;
 
   private:
-  util::MultiArray<File, 2, 2> rook_files_;
+    util::MultiArray<File, 2, 2> rook_files_;
 };
 
 #endif // CASTLE_RIGHTS_HPP

--- a/src/chess/castle_rights.hpp
+++ b/src/chess/castle_rights.hpp
@@ -27,7 +27,7 @@ class CastleRights {
     [[nodiscard]] u8 to_mask() const;
 
   private:
-    MultiArray<File, 2, 2> rook_files_;
+  util::MultiArray<File, 2, 2> rook_files_;
 };
 
 #endif // CASTLE_RIGHTS_HPP

--- a/src/chess/magics.cpp
+++ b/src/chess/magics.cpp
@@ -114,12 +114,12 @@ Bitboard compute_rook_attacks(Square sq, Bitboard occ) {
     return (attacks_rank & rank) | (attacks_file & file);
 }
 
-MultiArray<Bitboard, 64, 512> BISHOP_ATTACKS = []() {
+util::MultiArray<Bitboard, 64, 512> BISHOP_ATTACKS = []() {
     return generate_attacks_table<decltype(BISHOP_ATTACKS), decltype(BISHOP_MAGICS)::value_type, 512>(
         BISHOP_MAGICS, compute_bishop_attacks, get_bishop_attack_idx);
 }();
 
-MultiArray<Bitboard, 64, 4096> ROOK_ATTACKS = []() {
+util::MultiArray<Bitboard, 64, 4096> ROOK_ATTACKS = []() {
     return generate_attacks_table<decltype(ROOK_ATTACKS), decltype(ROOK_MAGICS)::value_type, 4096>(
         ROOK_MAGICS, compute_rook_attacks, get_rook_attack_idx);
 }();

--- a/src/chess/magics.hpp
+++ b/src/chess/magics.hpp
@@ -147,8 +147,8 @@ constexpr std::array<MagicEntry, 64> BISHOP_MAGICS = {
 };
 // clang-format on
 
-extern MultiArray<Bitboard, 64, 512> BISHOP_ATTACKS;
-extern MultiArray<Bitboard, 64, 4096> ROOK_ATTACKS;
+extern util::MultiArray<Bitboard, 64, 512> BISHOP_ATTACKS;
+extern util::MultiArray<Bitboard, 64, 4096> ROOK_ATTACKS;
 
 [[nodiscard]] Bitboard compute_bishop_attacks(Square sq, Bitboard occ);
 [[nodiscard]] Bitboard compute_rook_attacks(Square sq, Bitboard occ);

--- a/src/chess/zobrist.hpp
+++ b/src/chess/zobrist.hpp
@@ -9,7 +9,7 @@ using HashKey = u64;
 
 namespace zobrist {
 
-using PieceTable = MultiArray<HashKey, 6, 2, 64>;
+using PieceTable = util::MultiArray<HashKey, 6, 2, 64>;
 using CastleRightsTable = std::array<HashKey, 16>;
 using EnPassantTable = std::array<HashKey, 8>;
 

--- a/src/eval/network.cpp
+++ b/src/eval/network.cpp
@@ -1,0 +1,58 @@
+#include "network.hpp"
+
+#include "../third_party/incbin.h"
+#include <algorithm>
+#include <array>
+#include <cstring>
+
+#define EVALFILE "net.nnue"
+INCBIN(EVAL, EVALFILE);
+
+const Network *network = reinterpret_cast<const Network *>(gEVALData);
+
+usize feature_idx(Square sq, PieceType piece, Color piece_color, Color perspective) {
+    usize flip = 0b111000 * perspective;
+    return piece_color * 6 * 64 + piece * 64 + sq;
+}
+
+i32 evaluate(const BoardState &state) {
+    std::array<i16Vec, L1_SIZE / VECTOR_SIZE> stm_accumulator, nstm_accumulator;
+    std::memcpy(stm_accumulator.data(), network->ft_biases.data(), sizeof(stm_accumulator));
+    std::memcpy(nstm_accumulator.data(), network->ft_biases.data(), sizeof(nstm_accumulator));
+
+    const auto stm = state.side_to_move;
+    { // add all the features
+        const auto stm_occ = state.side_bbs[stm];
+        const auto nstm_occ = state.side_bbs[~stm];
+        for (int pti = PieceType::PAWN; pti <= PieceType::KING; ++pti) {
+            const auto piece = PieceType(pti);
+            for (auto sq : state.piece_bbs[piece] & stm_occ) {
+                for (usize i = 0; i < L1_SIZE / VECTOR_SIZE; ++i) {
+                    stm_accumulator[i] += network->ft_weights_vec[feature_idx(sq, piece, stm, stm)][i];
+                    nstm_accumulator[i] += network->ft_weights_vec[feature_idx(sq, piece, stm, ~stm)][i];
+                }
+            }
+            for (auto sq : state.piece_bbs[piece] & nstm_occ) {
+                for (usize i = 0; i < L1_SIZE / VECTOR_SIZE; ++i) {
+                    stm_accumulator[i] += network->ft_weights_vec[feature_idx(sq, piece, ~stm, stm)][i];
+                    nstm_accumulator[i] += network->ft_weights_vec[feature_idx(sq, piece, ~stm, ~stm)][i];
+                }
+            }
+        }
+    }
+
+    util::SimdVector<i32, VECTOR_SIZE / 2> result_vec{};
+    // TODO: make this nicer, not sure how
+    // CReLU
+    for (usize i = 0; i < L1_SIZE / VECTOR_SIZE; ++i) {
+        const auto stm_val = util::max_epi16({}, stm_accumulator[i] * network->l1_weights[0][i]);
+        const auto nstm_val = util::max_epi16({}, nstm_accumulator[i] * network->l1_weights[1][i]);
+        result_vec += util::convert_vector<i32, i16, VECTOR_SIZE / 2>(util::lower_half<i16, VECTOR_SIZE>(stm_val));
+        result_vec += util::convert_vector<i32, i16, VECTOR_SIZE / 2>(util::upper_half<i16, VECTOR_SIZE>(stm_val));
+        result_vec += util::convert_vector<i32, i16, VECTOR_SIZE / 2>(util::lower_half<i16, VECTOR_SIZE>(nstm_val));
+        result_vec += util::convert_vector<i32, i16, VECTOR_SIZE / 2>(util::upper_half<i16, VECTOR_SIZE>(nstm_val));
+    }
+    const auto result = util::reduce_vector<i32, VECTOR_SIZE / 2>(result_vec) + network->l1_biases[0];
+
+    return result * SCALE / (QA * QB);
+}

--- a/src/eval/network.cpp
+++ b/src/eval/network.cpp
@@ -1,10 +1,8 @@
 #include "network.hpp"
 
 #include "../third_party/incbin.h"
-#include <algorithm>
 #include <array>
 #include <cstring>
-#include <iostream>
 
 INCBIN(EVAL, EVALFILE);
 

--- a/src/eval/network.cpp
+++ b/src/eval/network.cpp
@@ -16,31 +16,25 @@ const util::MultiArray<i16Vec, L1_SIZE / VECTOR_SIZE> &feature(Square sq, PieceT
     return network->ft_weights_vec[piece_color != perspective][piece - 1][sq ^ flip];
 }
 
-i32 evaluate(const BoardState &state) {
+f64 evaluate(const BoardState &state) {
     std::array<i16Vec, L1_SIZE / VECTOR_SIZE> accumulator;
     std::memcpy(accumulator.data(), network->ft_biases.data(), sizeof(accumulator));
 
     const auto stm = state.side_to_move;
-    { // add all the features
-        const auto stm_occ = state.side_bbs[stm];
-        const auto nstm_occ = state.side_bbs[~stm];
-        for (int pti = PieceType::PAWN; pti <= PieceType::KING; ++pti) {
-            const auto piece = PieceType(pti);
-            for (auto sq : state.piece_bbs[piece - 1] & stm_occ) {
-                for (usize i = 0; i < L1_SIZE / VECTOR_SIZE; ++i) {
-                    accumulator[i] += feature(sq, piece, stm, stm)[i];
-                }
+    // add all the features
+    for (PieceType piece = PieceType::PAWN; piece <= PieceType::KING; piece = PieceType(piece + 1)) {
+        for (auto sq : state.piece_bbs[piece - 1] & state.occupancy(stm)) {
+            for (usize i = 0; i < L1_SIZE / VECTOR_SIZE; ++i) {
+                accumulator[i] += feature(sq, piece, stm, stm)[i];
             }
-            for (auto sq : state.piece_bbs[piece - 1] & nstm_occ) {
-                for (usize i = 0; i < L1_SIZE / VECTOR_SIZE; ++i) {
-                    accumulator[i] += feature(sq, piece, ~stm, stm)[i];
-                }
+        }
+        for (auto sq : state.piece_bbs[piece - 1] & state.occupancy(~stm)) {
+            for (usize i = 0; i < L1_SIZE / VECTOR_SIZE; ++i) {
+                accumulator[i] += feature(sq, piece, ~stm, stm)[i];
             }
         }
     }
 
-    // TODO: make this nicer, not sure how
-    // CReLU
     const auto zero = util::set1_epi16<VECTOR_SIZE>(0);
     const auto one = util::set1_epi16<VECTOR_SIZE>(QA);
 
@@ -51,6 +45,7 @@ i32 evaluate(const BoardState &state) {
     }
     const auto result = util::reduce_vector<i32, VECTOR_SIZE / 2>(result_vec);
 
-    return (result + network->l1_biases[0]) * SCALE / (QA * QB);
+    return static_cast<f64>(result + network->l1_biases[0]) / static_cast<f64>(QA * QB);
 }
+
 } // namespace network

--- a/src/eval/network.cpp
+++ b/src/eval/network.cpp
@@ -4,15 +4,18 @@
 #include <algorithm>
 #include <array>
 #include <cstring>
+#include <iostream>
 
-#define EVALFILE "net.nnue"
 INCBIN(EVAL, EVALFILE);
+
+namespace network {
 
 const Network *network = reinterpret_cast<const Network *>(gEVALData);
 
-usize feature_idx(Square sq, PieceType piece, Color piece_color, Color perspective) {
+const util::MultiArray<i16Vec, L1_SIZE / VECTOR_SIZE> &feature(Square sq, PieceType piece, Color piece_color,
+                                                               Color perspective) {
     usize flip = 0b111000 * perspective;
-    return piece_color * 6 * 64 + piece * 64 + sq;
+    return network->ft_weights_vec[piece_color != perspective][piece - 1][sq ^ flip];
 }
 
 i32 evaluate(const BoardState &state) {
@@ -26,33 +29,37 @@ i32 evaluate(const BoardState &state) {
         const auto nstm_occ = state.side_bbs[~stm];
         for (int pti = PieceType::PAWN; pti <= PieceType::KING; ++pti) {
             const auto piece = PieceType(pti);
-            for (auto sq : state.piece_bbs[piece] & stm_occ) {
+            for (auto sq : state.piece_bbs[piece - 1] & stm_occ) {
                 for (usize i = 0; i < L1_SIZE / VECTOR_SIZE; ++i) {
-                    stm_accumulator[i] += network->ft_weights_vec[feature_idx(sq, piece, stm, stm)][i];
-                    nstm_accumulator[i] += network->ft_weights_vec[feature_idx(sq, piece, stm, ~stm)][i];
+                    stm_accumulator[i] += feature(sq, piece, stm, stm)[i];
+                    nstm_accumulator[i] += feature(sq, piece, stm, ~stm)[i];
                 }
             }
-            for (auto sq : state.piece_bbs[piece] & nstm_occ) {
+            for (auto sq : state.piece_bbs[piece - 1] & nstm_occ) {
                 for (usize i = 0; i < L1_SIZE / VECTOR_SIZE; ++i) {
-                    stm_accumulator[i] += network->ft_weights_vec[feature_idx(sq, piece, ~stm, stm)][i];
-                    nstm_accumulator[i] += network->ft_weights_vec[feature_idx(sq, piece, ~stm, ~stm)][i];
+                    stm_accumulator[i] += feature(sq, piece, ~stm, stm)[i];
+                    nstm_accumulator[i] += feature(sq, piece, ~stm, ~stm)[i];
                 }
             }
         }
     }
 
-    util::SimdVector<i32, VECTOR_SIZE / 2> result_vec{};
     // TODO: make this nicer, not sure how
     // CReLU
-    for (usize i = 0; i < L1_SIZE / VECTOR_SIZE; ++i) {
-        const auto stm_val = util::max_epi16({}, stm_accumulator[i] * network->l1_weights[0][i]);
-        const auto nstm_val = util::max_epi16({}, nstm_accumulator[i] * network->l1_weights[1][i]);
-        result_vec += util::convert_vector<i32, i16, VECTOR_SIZE / 2>(util::lower_half<i16, VECTOR_SIZE>(stm_val));
-        result_vec += util::convert_vector<i32, i16, VECTOR_SIZE / 2>(util::upper_half<i16, VECTOR_SIZE>(stm_val));
-        result_vec += util::convert_vector<i32, i16, VECTOR_SIZE / 2>(util::lower_half<i16, VECTOR_SIZE>(nstm_val));
-        result_vec += util::convert_vector<i32, i16, VECTOR_SIZE / 2>(util::upper_half<i16, VECTOR_SIZE>(nstm_val));
-    }
-    const auto result = util::reduce_vector<i32, VECTOR_SIZE / 2>(result_vec) + network->l1_biases[0];
+    const auto zero = util::set1_epi16<VECTOR_SIZE>(0);
+    const auto one = util::set1_epi16<VECTOR_SIZE>(QA);
 
-    return result * SCALE / (QA * QB);
+    util::SimdVector<i32, VECTOR_SIZE / 2> result_vec{};
+    for (usize i = 0; i < L1_SIZE / VECTOR_SIZE; ++i) {
+        const auto stm_clamped =
+            util::min_epi16<VECTOR_SIZE>(util::max_epi16<VECTOR_SIZE>(stm_accumulator[i], zero), one);
+        const auto nstm_clamped =
+            util::min_epi16<VECTOR_SIZE>(util::max_epi16<VECTOR_SIZE>(nstm_accumulator[i], zero), one);
+        result_vec += util::madd_epi16(stm_clamped, network->l1_weights_vec[0][i]);
+        result_vec += util::madd_epi16(nstm_clamped, network->l1_weights_vec[1][i]);
+    }
+    const auto result = util::reduce_vector<i32, VECTOR_SIZE / 2>(result_vec) ;
+
+    return (result + network->l1_biases[0]) * SCALE / (QA * QB);
 }
+} // namespace network

--- a/src/eval/network.hpp
+++ b/src/eval/network.hpp
@@ -1,0 +1,28 @@
+#ifndef NETWORK_HPP
+#define NETWORK_HPP
+
+#include "../chess/board_state.hpp"
+#include "../util/multi_array.hpp"
+#include "../util/simd.hpp"
+#include <array>
+
+constexpr static auto QA = 64;
+constexpr static auto QB = 255;
+constexpr static auto SCALE = 400;
+constexpr static auto L1_SIZE = 16;
+constexpr static auto VECTOR_SIZE = std::min<usize>(L1_SIZE, util::NATIVE_SIZE<i16>);
+using i16Vec = util::SimdVector<i16, VECTOR_SIZE>;
+
+i32 evaluate(const BoardState &state);
+
+struct Network {
+    union {
+        alignas(util::NATIVE_VECTOR_ALIGNMENT) util::MultiArray<i16, 768, L1_SIZE / VECTOR_SIZE> ft_weights_vec;
+        alignas(util::NATIVE_VECTOR_ALIGNMENT) util::MultiArray<i16, 768, L1_SIZE> ft_weights;
+    };
+    alignas(util::NATIVE_VECTOR_ALIGNMENT) std::array<i16, L1_SIZE> ft_biases;
+    alignas(util::NATIVE_VECTOR_ALIGNMENT) util::MultiArray<i16, 2, L1_SIZE> l1_weights;
+    alignas(util::NATIVE_VECTOR_ALIGNMENT) std::array<i16, 1> l1_biases;
+};
+
+#endif // NETWORK_HPP

--- a/src/eval/network.hpp
+++ b/src/eval/network.hpp
@@ -11,7 +11,7 @@ namespace network {
 constexpr static auto QA = 255;
 constexpr static auto QB = 64;
 constexpr static auto SCALE = 400;
-constexpr static auto L1_SIZE = 16;
+constexpr static auto L1_SIZE = 32;
 constexpr static auto VECTOR_SIZE = std::min<usize>(L1_SIZE, util::NATIVE_SIZE<i16>);
 using i16Vec = util::SimdVector<i16, VECTOR_SIZE>;
 

--- a/src/eval/network.hpp
+++ b/src/eval/network.hpp
@@ -24,8 +24,8 @@ struct alignas(util::NATIVE_VECTOR_ALIGNMENT) Network {
     };
     std::array<i16, L1_SIZE> ft_biases;
     union {
-        util::MultiArray<i16Vec, 2, L1_SIZE / VECTOR_SIZE> l1_weights_vec;
-        util::MultiArray<i16, 2, L1_SIZE> l1_weights;
+        util::MultiArray<i16Vec, L1_SIZE / VECTOR_SIZE> l1_weights_vec;
+        util::MultiArray<i16, L1_SIZE> l1_weights;
     };
     std::array<i16, 1> l1_biases;
 };

--- a/src/eval/network.hpp
+++ b/src/eval/network.hpp
@@ -8,14 +8,13 @@
 
 namespace network {
 
-constexpr static auto QA = 255;
-constexpr static auto QB = 64;
-constexpr static auto SCALE = 400;
-constexpr static auto L1_SIZE = 32;
-constexpr static auto VECTOR_SIZE = std::min<usize>(L1_SIZE, util::NATIVE_SIZE<i16>);
+constexpr static i16 QA = 255;
+constexpr static i16 QB = 64;
+constexpr static usize L1_SIZE = 32;
+constexpr static usize VECTOR_SIZE = std::min<usize>(L1_SIZE, util::NATIVE_SIZE<i16>);
 using i16Vec = util::SimdVector<i16, VECTOR_SIZE>;
 
-i32 evaluate(const BoardState &state);
+f64 evaluate(const BoardState &state);
 
 struct alignas(util::NATIVE_VECTOR_ALIGNMENT) Network {
     union {

--- a/src/eval/network.hpp
+++ b/src/eval/network.hpp
@@ -8,10 +8,10 @@
 
 namespace network {
 
-constexpr static i16 QA = 255;
-constexpr static i16 QB = 64;
-constexpr static usize L1_SIZE = 32;
-constexpr static usize VECTOR_SIZE = std::min<usize>(L1_SIZE, util::NATIVE_SIZE<i16>);
+constexpr i16 QA = 255;
+constexpr i16 QB = 64;
+constexpr usize L1_SIZE = 32;
+constexpr usize VECTOR_SIZE = std::min<usize>(L1_SIZE, util::NATIVE_SIZE<i16>);
 using i16Vec = util::SimdVector<i16, VECTOR_SIZE>;
 
 f64 evaluate(const BoardState &state);

--- a/src/eval/network.hpp
+++ b/src/eval/network.hpp
@@ -6,8 +6,10 @@
 #include "../util/simd.hpp"
 #include <array>
 
-constexpr static auto QA = 64;
-constexpr static auto QB = 255;
+namespace network {
+
+constexpr static auto QA = 255;
+constexpr static auto QB = 64;
 constexpr static auto SCALE = 400;
 constexpr static auto L1_SIZE = 16;
 constexpr static auto VECTOR_SIZE = std::min<usize>(L1_SIZE, util::NATIVE_SIZE<i16>);
@@ -15,14 +17,18 @@ using i16Vec = util::SimdVector<i16, VECTOR_SIZE>;
 
 i32 evaluate(const BoardState &state);
 
-struct Network {
+struct alignas(util::NATIVE_VECTOR_ALIGNMENT) Network {
     union {
-        alignas(util::NATIVE_VECTOR_ALIGNMENT) util::MultiArray<i16, 768, L1_SIZE / VECTOR_SIZE> ft_weights_vec;
-        alignas(util::NATIVE_VECTOR_ALIGNMENT) util::MultiArray<i16, 768, L1_SIZE> ft_weights;
+        util::MultiArray<i16Vec, 2, 6, 64, L1_SIZE / VECTOR_SIZE> ft_weights_vec;
+        util::MultiArray<i16, 2, 6, 64, L1_SIZE> ft_weights;
     };
-    alignas(util::NATIVE_VECTOR_ALIGNMENT) std::array<i16, L1_SIZE> ft_biases;
-    alignas(util::NATIVE_VECTOR_ALIGNMENT) util::MultiArray<i16, 2, L1_SIZE> l1_weights;
-    alignas(util::NATIVE_VECTOR_ALIGNMENT) std::array<i16, 1> l1_biases;
+    std::array<i16, L1_SIZE> ft_biases;
+    union {
+        util::MultiArray<i16Vec, 2, L1_SIZE / VECTOR_SIZE> l1_weights_vec;
+        util::MultiArray<i16, 2, L1_SIZE> l1_weights;
+    };
+    std::array<i16, 1> l1_biases;
 };
+} // namespace network
 
 #endif // NETWORK_HPP

--- a/src/search/game_tree.cpp
+++ b/src/search/game_tree.cpp
@@ -184,25 +184,16 @@ f64 GameTree::simulate_node(u32 node_idx) {
     }
 
     const auto &state = board_.state();
-    // const i32 stm_material =
-    //     100 * state.pawns(state.side_to_move).pop_count() + 280 * state.knights(state.side_to_move).pop_count() +
-    //     310 * state.bishops(state.side_to_move).pop_count() + 500 * state.rooks(state.side_to_move).pop_count() +
-    //     1000 * state.queens(state.side_to_move).pop_count();
-    // const i32 nstm_material =
-    //     100 * state.pawns(~state.side_to_move).pop_count() + 280 * state.knights(~state.side_to_move).pop_count() +
-    //     310 * state.bishops(~state.side_to_move).pop_count() + 500 * state.rooks(~state.side_to_move).pop_count() +
-    //     1000 * state.queens(~state.side_to_move).pop_count();
-    // const f64 eval = stm_material - nstm_material + 20;
     const f64 eval = network::evaluate(state);
 
-    return 1.0 / (1.0 + std::exp(-eval / 400.0));
+    return 1.0 / (1.0 + std::exp(-eval));
 }
 
 void GameTree::backpropagate_terminal_state(u32 node_idx, TerminalState child_terminal_state) {
     auto &node = nodes_[node_idx];
     switch (child_terminal_state.flag()) {
     case TerminalState::Flag::LOSS: { // If a child node is lost, then it's a win for us
-        // Ensure that if we already had a shorter mate we preserve it 
+        // Ensure that if we already had a shorter mate we preserve it
         const auto current_mate_distance =
             node.terminal_state.is_win() ? node.terminal_state.distance_to_terminal() : 255;
         node.terminal_state =

--- a/src/search/game_tree.cpp
+++ b/src/search/game_tree.cpp
@@ -184,9 +184,7 @@ f64 GameTree::simulate_node(u32 node_idx) {
     }
 
     const auto &state = board_.state();
-    const f64 eval = network::evaluate(state);
-
-    return 1.0 / (1.0 + std::exp(-eval));
+    return 1.0 / (1.0 + std::exp(-network::evaluate(state)));
 }
 
 void GameTree::backpropagate_terminal_state(u32 node_idx, TerminalState child_terminal_state) {

--- a/src/search/game_tree.cpp
+++ b/src/search/game_tree.cpp
@@ -1,5 +1,6 @@
 #include "game_tree.hpp"
 #include "../chess/move_gen.hpp"
+#include "../eval/network.hpp"
 #include "../util/assert.hpp"
 #include "node.hpp"
 #include <algorithm>
@@ -183,15 +184,17 @@ f64 GameTree::simulate_node(u32 node_idx) {
     }
 
     const auto &state = board_.state();
-    const i32 stm_material =
-        100 * state.pawns(state.side_to_move).pop_count() + 280 * state.knights(state.side_to_move).pop_count() +
-        310 * state.bishops(state.side_to_move).pop_count() + 500 * state.rooks(state.side_to_move).pop_count() +
-        1000 * state.queens(state.side_to_move).pop_count();
-    const i32 nstm_material =
-        100 * state.pawns(~state.side_to_move).pop_count() + 280 * state.knights(~state.side_to_move).pop_count() +
-        310 * state.bishops(~state.side_to_move).pop_count() + 500 * state.rooks(~state.side_to_move).pop_count() +
-        1000 * state.queens(~state.side_to_move).pop_count();
-    const f64 eval = stm_material - nstm_material + 20;
+    // const i32 stm_material =
+    //     100 * state.pawns(state.side_to_move).pop_count() + 280 * state.knights(state.side_to_move).pop_count() +
+    //     310 * state.bishops(state.side_to_move).pop_count() + 500 * state.rooks(state.side_to_move).pop_count() +
+    //     1000 * state.queens(state.side_to_move).pop_count();
+    // const i32 nstm_material =
+    //     100 * state.pawns(~state.side_to_move).pop_count() + 280 * state.knights(~state.side_to_move).pop_count() +
+    //     310 * state.bishops(~state.side_to_move).pop_count() + 500 * state.rooks(~state.side_to_move).pop_count() +
+    //     1000 * state.queens(~state.side_to_move).pop_count();
+    // const f64 eval = stm_material - nstm_material + 20;
+    const f64 eval = network::evaluate(state);
+
     return 1.0 / (1.0 + std::exp(-eval / 400.0));
 }
 

--- a/src/third_party/incbin.h
+++ b/src/third_party/incbin.h
@@ -1,0 +1,476 @@
+/**
+ * @file incbin.h
+ * @author Dale Weiler
+ * @brief Utility for including binary files
+ *
+ * Facilities for including binary files into the current translation unit and
+ * making use from them externally in other translation units.
+ */
+#ifndef INCBIN_HDR
+#define INCBIN_HDR
+#include <limits.h>
+#if   defined(__AVX512BW__) || \
+      defined(__AVX512CD__) || \
+      defined(__AVX512DQ__) || \
+      defined(__AVX512ER__) || \
+      defined(__AVX512PF__) || \
+      defined(__AVX512VL__) || \
+      defined(__AVX512F__)
+# define INCBIN_ALIGNMENT_INDEX 6
+#elif defined(__AVX__)      || \
+      defined(__AVX2__)
+# define INCBIN_ALIGNMENT_INDEX 5
+#elif defined(__SSE__)      || \
+      defined(__SSE2__)     || \
+      defined(__SSE3__)     || \
+      defined(__SSSE3__)    || \
+      defined(__SSE4_1__)   || \
+      defined(__SSE4_2__)   || \
+      defined(__neon__)     || \
+      defined(__ARM_NEON)   || \
+      defined(__ALTIVEC__)
+# define INCBIN_ALIGNMENT_INDEX 4
+#elif ULONG_MAX != 0xffffffffu
+# define INCBIN_ALIGNMENT_INDEX 3
+# else
+# define INCBIN_ALIGNMENT_INDEX 2
+#endif
+
+/* Lookup table of (1 << n) where `n' is `INCBIN_ALIGNMENT_INDEX' */
+#define INCBIN_ALIGN_SHIFT_0 1
+#define INCBIN_ALIGN_SHIFT_1 2
+#define INCBIN_ALIGN_SHIFT_2 4
+#define INCBIN_ALIGN_SHIFT_3 8
+#define INCBIN_ALIGN_SHIFT_4 16
+#define INCBIN_ALIGN_SHIFT_5 32
+#define INCBIN_ALIGN_SHIFT_6 64
+
+/* Actual alignment value */
+#define INCBIN_ALIGNMENT \
+    INCBIN_CONCATENATE( \
+        INCBIN_CONCATENATE(INCBIN_ALIGN_SHIFT, _), \
+        INCBIN_ALIGNMENT_INDEX)
+
+/* Stringize */
+#define INCBIN_STR(X) \
+    #X
+#define INCBIN_STRINGIZE(X) \
+    INCBIN_STR(X)
+/* Concatenate */
+#define INCBIN_CAT(X, Y) \
+    X ## Y
+#define INCBIN_CONCATENATE(X, Y) \
+    INCBIN_CAT(X, Y)
+/* Deferred macro expansion */
+#define INCBIN_EVAL(X) \
+    X
+#define INCBIN_INVOKE(N, ...) \
+    INCBIN_EVAL(N(__VA_ARGS__))
+/* Variable argument count for overloading by arity */
+#define INCBIN_VA_ARG_COUNTER(_1, _2, _3, N, ...) N
+#define INCBIN_VA_ARGC(...) INCBIN_VA_ARG_COUNTER(__VA_ARGS__, 3, 2, 1, 0)
+
+/* Green Hills uses a different directive for including binary data */
+#if defined(__ghs__)
+#  if (__ghs_asm == 2)
+#    define INCBIN_MACRO ".file"
+/* Or consider the ".myrawdata" entry in the ld file */
+#  else
+#    define INCBIN_MACRO "\tINCBIN"
+#  endif
+#else
+#  define INCBIN_MACRO ".incbin"
+#endif
+
+#ifndef _MSC_VER
+#  define INCBIN_ALIGN \
+    __attribute__((aligned(INCBIN_ALIGNMENT)))
+#else
+#  define INCBIN_ALIGN __declspec(align(INCBIN_ALIGNMENT))
+#endif
+
+#if defined(__arm__) || /* GNU C and RealView */ \
+    defined(__arm) || /* Diab */ \
+    defined(_ARM) /* ImageCraft */
+#  define INCBIN_ARM
+#endif
+
+#ifdef __GNUC__
+/* Utilize .balign where supported */
+#  define INCBIN_ALIGN_HOST ".balign " INCBIN_STRINGIZE(INCBIN_ALIGNMENT) "\n"
+#  define INCBIN_ALIGN_BYTE ".balign 1\n"
+#elif defined(INCBIN_ARM)
+/*
+ * On arm assemblers, the alignment value is calculated as (1 << n) where `n' is
+ * the shift count. This is the value passed to `.align'
+ */
+#  define INCBIN_ALIGN_HOST ".align " INCBIN_STRINGIZE(INCBIN_ALIGNMENT_INDEX) "\n"
+#  define INCBIN_ALIGN_BYTE ".align 0\n"
+#else
+/* We assume other inline assembler's treat `.align' as `.balign' */
+#  define INCBIN_ALIGN_HOST ".align " INCBIN_STRINGIZE(INCBIN_ALIGNMENT) "\n"
+#  define INCBIN_ALIGN_BYTE ".align 1\n"
+#endif
+
+/* INCBIN_CONST is used by incbin.c generated files */
+#if defined(__cplusplus)
+#  define INCBIN_EXTERNAL extern "C"
+#  define INCBIN_CONST    extern const
+#else
+#  define INCBIN_EXTERNAL extern
+#  define INCBIN_CONST    const
+#endif
+
+/**
+ * @brief Optionally override the linker section into which size and data is
+ * emitted.
+ * 
+ * @warning If you use this facility, you might have to deal with
+ * platform-specific linker output section naming on your own.
+ */
+#if !defined(INCBIN_OUTPUT_SECTION)
+#  if defined(__APPLE__)
+#    define INCBIN_OUTPUT_SECTION ".const_data"
+#  else
+#    define INCBIN_OUTPUT_SECTION ".rodata"
+#  endif
+#endif
+
+/**
+ * @brief Optionally override the linker section into which data is emitted.
+ *
+ * @warning If you use this facility, you might have to deal with
+ * platform-specific linker output section naming on your own.
+ */
+#if !defined(INCBIN_OUTPUT_DATA_SECTION)
+#  define INCBIN_OUTPUT_DATA_SECTION INCBIN_OUTPUT_SECTION
+#endif
+
+/**
+ * @brief Optionally override the linker section into which size is emitted.
+ *
+ * @warning If you use this facility, you might have to deal with
+ * platform-specific linker output section naming on your own.
+ * 
+ * @note This is useful for Harvard architectures where program memory cannot
+ * be directly read from the program without special instructions. With this you
+ * can chose to put the size variable in RAM rather than ROM.
+ */
+#if !defined(INCBIN_OUTPUT_SIZE_SECTION)
+#  define INCBIN_OUTPUT_SIZE_SECTION INCBIN_OUTPUT_SECTION
+#endif
+
+#if defined(__APPLE__)
+#  include <TargetConditionals.h>
+#  if defined(TARGET_OS_IPHONE) && !defined(INCBIN_SILENCE_BITCODE_WARNING)
+#    warning "incbin is incompatible with bitcode. Using the library will break upload to App Store if you have bitcode enabled. Add `#define INCBIN_SILENCE_BITCODE_WARNING` before including this header to silence this warning."
+#  endif
+/* The directives are different for Apple branded compilers */
+#  define INCBIN_SECTION         INCBIN_OUTPUT_SECTION "\n"
+#  define INCBIN_GLOBAL(NAME)    ".globl " INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
+#  define INCBIN_INT             ".long "
+#  define INCBIN_MANGLE          "_"
+#  define INCBIN_BYTE            ".byte "
+#  define INCBIN_TYPE(...)
+#else
+#  define INCBIN_SECTION         ".section " INCBIN_OUTPUT_SECTION "\n"
+#  define INCBIN_GLOBAL(NAME)    ".global " INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
+#  if defined(__ghs__)
+#    define INCBIN_INT           ".word "
+#  else
+#    define INCBIN_INT           ".int "
+#  endif
+#  if defined(__USER_LABEL_PREFIX__)
+#    define INCBIN_MANGLE        INCBIN_STRINGIZE(__USER_LABEL_PREFIX__)
+#  else
+#    define INCBIN_MANGLE        ""
+#  endif
+#  if defined(INCBIN_ARM)
+/* On arm assemblers, `@' is used as a line comment token */
+#    define INCBIN_TYPE(NAME)    ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", %object\n"
+#  elif defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
+/* Mingw and Cygwin don't support this directive either */
+#    define INCBIN_TYPE(NAME)
+#  else
+/* It's safe to use `@' on other architectures */
+#    define INCBIN_TYPE(NAME)    ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", @object\n"
+#  endif
+#  define INCBIN_BYTE            ".byte "
+#endif
+
+/* List of style types used for symbol names */
+#define INCBIN_STYLE_CAMEL 0
+#define INCBIN_STYLE_SNAKE 1
+
+/**
+ * @brief Specify the prefix to use for symbol names.
+ *
+ * @note By default this is "g".
+ *
+ * @code
+ * #define INCBIN_PREFIX incbin
+ * #include "incbin.h"
+ * INCBIN(Foo, "foo.txt");
+ *
+ * // Now you have the following symbols instead:
+ * // const unsigned char incbinFoo<data>[];
+ * // const unsigned char *const incbinFoo<end>;
+ * // const unsigned int incbinFoo<size>;
+ * @endcode
+ */
+#if !defined(INCBIN_PREFIX)
+#  define INCBIN_PREFIX g
+#endif
+
+/**
+ * @brief Specify the style used for symbol names.
+ *
+ * Possible options are
+ * - INCBIN_STYLE_CAMEL "CamelCase"
+ * - INCBIN_STYLE_SNAKE "snake_case"
+ *
+ * @note By default this is INCBIN_STYLE_CAMEL
+ *
+ * @code
+ * #define INCBIN_STYLE INCBIN_STYLE_SNAKE
+ * #include "incbin.h"
+ * INCBIN(foo, "foo.txt");
+ *
+ * // Now you have the following symbols:
+ * // const unsigned char <prefix>foo_data[];
+ * // const unsigned char *const <prefix>foo_end;
+ * // const unsigned int <prefix>foo_size;
+ * @endcode
+ */
+#if !defined(INCBIN_STYLE)
+#  define INCBIN_STYLE INCBIN_STYLE_CAMEL
+#endif
+
+/* Style lookup tables */
+#define INCBIN_STYLE_0_DATA Data
+#define INCBIN_STYLE_0_END End
+#define INCBIN_STYLE_0_SIZE Size
+#define INCBIN_STYLE_1_DATA _data
+#define INCBIN_STYLE_1_END _end
+#define INCBIN_STYLE_1_SIZE _size
+
+/* Style lookup: returning identifier */
+#define INCBIN_STYLE_IDENT(TYPE) \
+    INCBIN_CONCATENATE( \
+        INCBIN_STYLE_, \
+        INCBIN_CONCATENATE( \
+            INCBIN_EVAL(INCBIN_STYLE), \
+            INCBIN_CONCATENATE(_, TYPE)))
+
+/* Style lookup: returning string literal */
+#define INCBIN_STYLE_STRING(TYPE) \
+    INCBIN_STRINGIZE( \
+        INCBIN_STYLE_IDENT(TYPE)) \
+
+/* Generate the global labels by indirectly invoking the macro with our style
+ * type and concatenating the name against them. */
+#define INCBIN_GLOBAL_LABELS(NAME, TYPE) \
+    INCBIN_INVOKE( \
+        INCBIN_GLOBAL, \
+        INCBIN_CONCATENATE( \
+            NAME, \
+            INCBIN_INVOKE( \
+                INCBIN_STYLE_IDENT, \
+                TYPE))) \
+    INCBIN_INVOKE( \
+        INCBIN_TYPE, \
+        INCBIN_CONCATENATE( \
+            NAME, \
+            INCBIN_INVOKE( \
+                INCBIN_STYLE_IDENT, \
+                TYPE)))
+
+/**
+ * @brief Externally reference binary data included in another translation unit.
+ *
+ * Produces three external symbols that reference the binary data included in
+ * another translation unit.
+ *
+ * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
+ * "Data", as well as "End" and "Size" after. An example is provided below.
+ *
+ * @param TYPE Optional array type. Omitting this picks a default of `unsigned char`.
+ * @param NAME The name given for the binary data
+ *
+ * @code
+ * INCBIN_EXTERN(Foo);
+ *
+ * // Now you have the following symbols:
+ * // extern const unsigned char <prefix>Foo<data>[];
+ * // extern const unsigned char *const <prefix>Foo<end>;
+ * // extern const unsigned int <prefix>Foo<size>;
+ * @endcode
+ * 
+ * You may specify a custom optional data type as well as the first argument.
+ * @code
+ * INCBIN_EXTERN(custom_type, Foo);
+ * 
+ * // Now you have the following symbols:
+ * // extern const custom_type <prefix>Foo<data>[];
+ * // extern const custom_type *const <prefix>Foo<end>;
+ * // extern const unsigned int <prefix>Foo<size>;
+ * @endcode
+ */
+#define INCBIN_EXTERN(...) \
+    INCBIN_CONCATENATE(INCBIN_EXTERN_, INCBIN_VA_ARGC(__VA_ARGS__))(__VA_ARGS__)
+#define INCBIN_EXTERN_1(NAME, ...) \
+    INCBIN_EXTERN_2(unsigned char, NAME)
+#define INCBIN_EXTERN_2(TYPE, NAME) \
+    INCBIN_EXTERNAL const INCBIN_ALIGN TYPE \
+        INCBIN_CONCATENATE( \
+            INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+            INCBIN_STYLE_IDENT(DATA))[]; \
+    INCBIN_EXTERNAL const INCBIN_ALIGN TYPE *const \
+    INCBIN_CONCATENATE( \
+        INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+        INCBIN_STYLE_IDENT(END)); \
+    INCBIN_EXTERNAL const unsigned int \
+        INCBIN_CONCATENATE( \
+            INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+            INCBIN_STYLE_IDENT(SIZE))
+
+/**
+ * @brief Externally reference textual data included in another translation unit.
+ *
+ * Produces three external symbols that reference the textual data included in
+ * another translation unit.
+ *
+ * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
+ * "Data", as well as "End" and "Size" after. An example is provided below.
+ *
+ * @param NAME The name given for the textual data
+ *
+ * @code
+ * INCBIN_EXTERN(Foo);
+ *
+ * // Now you have the following symbols:
+ * // extern const char <prefix>Foo<data>[];
+ * // extern const char *const <prefix>Foo<end>;
+ * // extern const unsigned int <prefix>Foo<size>;
+ * @endcode
+ */
+#define INCTXT_EXTERN(NAME) \
+    INCBIN_EXTERN_2(char, NAME)
+
+/**
+ * @brief Include a binary file into the current translation unit.
+ *
+ * Includes a binary file into the current translation unit, producing three symbols
+ * for objects that encode the data and size respectively.
+ *
+ * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
+ * "Data", as well as "End" and "Size" after. An example is provided below.
+ *
+ * @param TYPE Optional array type. Omitting this picks a default of `unsigned char`.
+ * @param NAME The name to associate with this binary data (as an identifier.)
+ * @param FILENAME The file to include (as a string literal.)
+ *
+ * @code
+ * INCBIN(Icon, "icon.png");
+ *
+ * // Now you have the following symbols:
+ * // const unsigned char <prefix>Icon<data>[];
+ * // const unsigned char *const <prefix>Icon<end>;
+ * // const unsigned int <prefix>Icon<size>;
+ * @endcode
+ * 
+ * You may specify a custom optional data type as well as the first argument.
+ * These macros are specialized by arity.
+ * @code
+ * INCBIN(custom_type, Icon, "icon.png");
+ *
+ * // Now you have the following symbols:
+ * // const custom_type <prefix>Icon<data>[];
+ * // const custom_type *const <prefix>Icon<end>;
+ * // const unsigned int <prefix>Icon<size>;
+ * @endcode
+ *
+ * @warning This must be used in global scope
+ * @warning The identifiers may be different if INCBIN_STYLE is not default
+ *
+ * To externally reference the data included by this in another translation unit
+ * please @see INCBIN_EXTERN.
+ */
+#ifdef _MSC_VER
+#  define INCBIN(NAME, FILENAME) \
+      INCBIN_EXTERN(NAME)
+#else
+#  define INCBIN(...) \
+     INCBIN_CONCATENATE(INCBIN_, INCBIN_VA_ARGC(__VA_ARGS__))(__VA_ARGS__)
+#  if defined(__GNUC__)
+#    define INCBIN_1(...) _Pragma("GCC error \"Single argument INCBIN not allowed\"")
+#  elif defined(__clang__)
+#    define INCBIN_1(...) _Pragma("clang error \"Single argument INCBIN not allowed\"")
+#  else
+#    define INCBIN_1(...) /* Cannot do anything here */
+#  endif
+#  define INCBIN_2(NAME, FILENAME) \
+      INCBIN_3(unsigned char, NAME, FILENAME)
+#  define INCBIN_3(TYPE, NAME, FILENAME) INCBIN_COMMON(TYPE, NAME, FILENAME, /* No terminator for binary data */)
+#  define INCBIN_COMMON(TYPE, NAME, FILENAME, TERMINATOR) \
+    __asm__(INCBIN_SECTION \
+            INCBIN_GLOBAL_LABELS(NAME, DATA) \
+            INCBIN_ALIGN_HOST \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(DATA) ":\n" \
+            INCBIN_MACRO " \"" FILENAME "\"\n" \
+                TERMINATOR \
+            INCBIN_GLOBAL_LABELS(NAME, END) \
+            INCBIN_ALIGN_BYTE \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) ":\n" \
+                INCBIN_BYTE "1\n" \
+            INCBIN_GLOBAL_LABELS(NAME, SIZE) \
+            INCBIN_ALIGN_HOST \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(SIZE) ":\n" \
+                INCBIN_INT INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) " - " \
+                           INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(DATA) "\n" \
+            INCBIN_ALIGN_HOST \
+            ".text\n" \
+    ); \
+    INCBIN_EXTERN(TYPE, NAME)
+#endif
+
+/**
+ * @brief Include a textual file into the current translation unit.
+ * 
+ * This behaves the same as INCBIN except it produces char compatible arrays
+ * and implicitly adds a null-terminator byte, thus the size of data included
+ * by this is one byte larger than that of INCBIN.
+ *
+ * Includes a textual file into the current translation unit, producing three
+ * symbols for objects that encode the data and size respectively.
+ *
+ * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
+ * "Data", as well as "End" and "Size" after. An example is provided below.
+ *
+ * @param NAME The name to associate with this binary data (as an identifier.)
+ * @param FILENAME The file to include (as a string literal.)
+ *
+ * @code
+ * INCTXT(Readme, "readme.txt");
+ *
+ * // Now you have the following symbols:
+ * // const char <prefix>Readme<data>[];
+ * // const char *const <prefix>Readme<end>;
+ * // const unsigned int <prefix>Readme<size>;
+ * @endcode
+ *
+ * @warning This must be used in global scope
+ * @warning The identifiers may be different if INCBIN_STYLE is not default
+ *
+ * To externally reference the data included by this in another translation unit
+ * please @see INCBIN_EXTERN.
+ */
+#if defined(_MSC_VER)
+#  define INCTXT(NAME, FILENAME) \
+     INCBIN_EXTERN(NAME)
+#else
+#  define INCTXT(NAME, FILENAME) \
+     INCBIN_COMMON(char, NAME, FILENAME, INCBIN_BYTE "0\n")
+#endif
+
+#endif

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -1,11 +1,11 @@
 #include "uci.hpp"
 #include "../chess/move_gen.hpp"
 #include "../data_gen/openings.hpp"
+#include "../eval/network.hpp"
 #include "../tests/bench.hpp"
 #include "../tests/perft.hpp"
 #include "../util/string.hpp"
 #include "../util/types.hpp"
-#include "../eval/network.hpp"
 
 #include <algorithm>
 #include <chrono>

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -5,6 +5,7 @@
 #include "../tests/perft.hpp"
 #include "../util/string.hpp"
 #include "../util/types.hpp"
+#include "../eval/network.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -104,6 +105,7 @@ void Handler::process_input(std::istream &in, std::ostream &out) {
         } else if (parts[0] == "perft") {
             handle_perft(out, *util::parse_int(parts[1]));
         } else if (parts[0] == "print") {
+            out << network::evaluate(board_.state()) << '\n';
             out << board_ << std::endl;
         } else if (parts[0] == "setoption") {
             handle_setoption(out, parts);

--- a/src/util/multi_array.hpp
+++ b/src/util/multi_array.hpp
@@ -4,6 +4,8 @@
 #include <array>
 #include <type_traits>
 
+namespace util {
+
 template <typename T, std::size_t Size, std::size_t... Sizes>
 class MultiArray;
 
@@ -159,5 +161,7 @@ class MultiArray {
         data_.swap(other.data_);
     }
 };
+
+} // namespace util
 
 #endif // MULTI_ARRAY_HPP

--- a/src/util/simd.hpp
+++ b/src/util/simd.hpp
@@ -1,0 +1,95 @@
+#ifndef SIMD_HPP
+#define SIMD_HPP
+
+#include "types.hpp"
+#include <cstring>
+
+namespace util {
+
+#if __x86_64__
+#if defined(__AVX512F__)
+constexpr auto NATIVE_VECTOR_BYTES = 64;
+#elif defined(__AVX2__)
+constexpr auto NATIVE_VECTOR_BYTES = 32;
+#elif defined(__SSE__)
+constexpr auto NATIVE_VECTOR_BYTES = 16;
+#else
+constexpr auto NATIVE_VECTOR_BYTES = 0;
+#endif
+#elif defined(__arm__) || defined(__aarch64__)
+#if defined(__ARM_NEON)
+constexpr auto NATIVE_VECTOR_BYTES = 16;
+#else
+constexpr auto NATIVE_VECTOR_BYTES = 0;
+#endif
+#endif
+
+namespace impl {
+
+template <class T, usize N>
+struct VectorHelper {
+    using Type __attribute__((__vector_size__(N * sizeof(T)))) = T; // get around GCC restriction
+};
+} // namespace impl
+
+constexpr auto NATIVE_VECTOR_ALIGNMENT = NATIVE_VECTOR_BYTES;
+
+template <class T, usize N>
+using SimdVector = typename impl::VectorHelper<T, N>::Type;
+
+template <class T>
+constexpr auto NATIVE_SIZE = NATIVE_VECTOR_BYTES / sizeof(T);
+
+template <class T>
+using NativeVector = SimdVector<T, NATIVE_SIZE<T>>;
+
+template <usize N = NATIVE_SIZE<i16>>
+inline SimdVector<i16, N> max_epi16(SimdVector<i16, N> a, SimdVector<i16, N> b) {
+    return __builtin_elementwise_max(a, b);
+}
+
+template <usize N = NATIVE_SIZE<i16>>
+inline SimdVector<i16, N> min_epi16(SimdVector<i16, N> a, SimdVector<i16, N> b) {
+    return __builtin_elementwise_min(a, b);
+}
+
+template <usize N = NATIVE_SIZE<i16>>
+inline SimdVector<i16, N> loadu_epi16(const i16 *ptr) {
+    SimdVector<i16, N> res;
+    std::memcpy(&res, ptr);
+    return res;
+}
+
+template <class To, class From, usize N>
+inline SimdVector<To, N> convert_vector(SimdVector<From, N> v) {
+    return __builtin_convertvector(v, SimdVector<To, N>);
+}
+
+template <class T, usize N>
+inline SimdVector<T, N / 2> lower_half(SimdVector<T, N> v) {
+    SimdVector<T, N / 2> res;
+    std::memcpy(&res, &v, sizeof(res));
+    return res;
+}
+
+template <class T, usize N>
+inline SimdVector<T, N / 2> upper_half(SimdVector<T, N> v) {
+    SimdVector<T, N / 2> res;
+    std::memcpy(&res, reinterpret_cast<const T *>(&v) + N / 2, sizeof(res));
+    return res;
+}
+
+template <class T, usize N>
+inline T reduce_vector(SimdVector<T, N> v) {
+    T vals[N];
+    std::memcpy(vals, &v, sizeof(vals));
+    T res = 0;
+    for (auto val : vals) {
+        res += val;
+    }
+    return res;
+}
+
+} // namespace util
+
+#endif // SIMD_HPP

--- a/src/util/types.hpp
+++ b/src/util/types.hpp
@@ -178,8 +178,8 @@ inline std::ostream &operator<<(std::ostream &os, Square sq) {
 class Color {
   public:
     enum ColorEnum : u8 {
-        WHITE,
-        BLACK,
+        WHITE = 0,
+        BLACK = 1,
         NO_COLOR = 2
     };
 


### PR DESCRIPTION
First Net
```
Elo   | 336.91 +- 53.37 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.05 (-2.25, 2.89) [0.00, 5.00]
Games | N: 350 W: 293 L: 31 D: 26
Penta | [0, 2, 29, 24, 120]
```
https://furybench.com/test/1954/

More training
```
Elo   | 27.33 +- 12.00 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2510 W: 1106 L: 909 D: 495
Penta | [156, 178, 464, 227, 230]
```
https://furybench.com/test/1959/

Removing Perspective
```
Elo   | 16.92 +- 9.36 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4294 W: 1835 L: 1626 D: 833
Penta | [307, 321, 765, 364, 390]
```
https://furybench.com/test/1965/

Not doing unnecessary multiply and divide by 400
```
Elo   | 0.49 +- 3.36 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 22476 W: 7740 L: 7708 D: 7028
Penta | [984, 2227, 4765, 2297, 965]
```
https://furybench.com/test/1967/

Second iteration net
```
Elo   | 172.27 +- 31.30 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.25 (-2.25, 2.89) [0.00, 5.00]
Games | N: 510 W: 331 L: 97 D: 82
Penta | [7, 17, 74, 49, 108]
```
https://furybench.com/test/1972/