### PR TITLE
Screlu Activation

### DIFF
--- a/src/eval/network.cpp
+++ b/src/eval/network.cpp
@@ -41,11 +41,11 @@ f64 evaluate(const BoardState &state) {
     util::SimdVector<i32, VECTOR_SIZE / 2> result_vec{};
     for (usize i = 0; i < L1_SIZE / VECTOR_SIZE; ++i) {
         const auto clamped = util::min_epi16<VECTOR_SIZE>(util::max_epi16<VECTOR_SIZE>(accumulator[i], zero), one);
-        result_vec += util::madd_epi16(clamped, network->l1_weights_vec[i]);
+        result_vec += util::madd_epi16(clamped, clamped * network->l1_weights_vec[i]);
     }
-    const auto result = util::reduce_vector<i32, VECTOR_SIZE / 2>(result_vec);
+    const auto result = static_cast<f64>(util::reduce_vector<i32, VECTOR_SIZE / 2>(result_vec)) / static_cast<f64>(QA);
 
-    return static_cast<f64>(result + network->l1_biases[0]) / static_cast<f64>(QA * QB);
+    return (result + static_cast<f64>(network->l1_biases[0])) / static_cast<f64>(QA * QB);
 }
 
 } // namespace network

--- a/src/eval/network.hpp
+++ b/src/eval/network.hpp
@@ -10,7 +10,7 @@ namespace network {
 
 constexpr i16 QA = 255;
 constexpr i16 QB = 64;
-constexpr usize L1_SIZE = 32;
+constexpr usize L1_SIZE = 64;
 constexpr usize VECTOR_SIZE = std::min<usize>(L1_SIZE, util::NATIVE_SIZE<i16>);
 using i16Vec = util::SimdVector<i16, VECTOR_SIZE>;
 

--- a/src/eval/network.hpp
+++ b/src/eval/network.hpp
@@ -10,7 +10,7 @@ namespace network {
 
 constexpr i16 QA = 255;
 constexpr i16 QB = 64;
-constexpr usize L1_SIZE = 64;
+constexpr usize L1_SIZE = 128;
 constexpr usize VECTOR_SIZE = std::min<usize>(L1_SIZE, util::NATIVE_SIZE<i16>);
 using i16Vec = util::SimdVector<i16, VECTOR_SIZE>;
 

--- a/src/search/game_tree.cpp
+++ b/src/search/game_tree.cpp
@@ -183,8 +183,7 @@ f64 GameTree::simulate_node(u32 node_idx) {
         return node.terminal_state.score();
     }
 
-    const auto &state = board_.state();
-    return 1.0 / (1.0 + std::exp(-network::evaluate(state)));
+    return 1.0 / (1.0 + std::exp(-network::evaluate(board_.state())));
 }
 
 void GameTree::backpropagate_terminal_state(u32 node_idx, TerminalState child_terminal_state) {


### PR DESCRIPTION
CReLU -> ScReLU
```
Elo   | 14.01 +- 8.09 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4888 W: 1848 L: 1651 D: 1389
Penta | [259, 467, 877, 500, 341]
```
https://furybench.com/test/1973/

Lower final LR
```
Elo   | 14.00 +- 8.12 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5040 W: 1962 L: 1759 D: 1319
Penta | [282, 479, 891, 490, 378]
```
https://furybench.com/test/1977/

64HL
```
Elo   | 41.71 +- 14.60 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1540 W: 647 L: 463 D: 430
Penta | [63, 132, 264, 180, 131]
```
https://furybench.com/test/1982/

128HL
```
Elo   | 7.45 +- 5.49 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11374 W: 4411 L: 4167 D: 2796
Penta | [736, 1013, 2061, 1025, 852]
```
https://furybench.com/test/1984/

Cosine LR -> Linear LR 
```
Elo   | 17.65 +- 9.27 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3822 W: 1481 L: 1287 D: 1054
Penta | [210, 346, 673, 404, 278]
```
https://furybench.com/test/1992/

New dataset
```
Elo   | 152.55 +- 29.89 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.04 (-2.25, 2.89) [0.00, 5.00]
Games | N: 528 W: 338 L: 120 D: 70
Penta | [13, 10, 89, 50, 102]
```
https://furybench.com/test/1993/

Bigger dataset
```
Elo   | 58.45 +- 17.76 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1134 W: 528 L: 339 D: 267
Penta | [47, 81, 194, 126, 119]
```
https://furybench.com/test/1994/

New dataset
```
Elo   | 86.28 +- 21.38 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.08 (-2.25, 2.89) [0.00, 5.00]
Games | N: 826 W: 414 L: 213 D: 199
Penta | [31, 42, 135, 105, 100]
```
https://furybench.com/test/1999/

bench: 1683429