### PR TITLE
Bigger network

### DIFF
--- a/src/eval/network.hpp
+++ b/src/eval/network.hpp
@@ -10,7 +10,7 @@ namespace network {
 
 constexpr i16 QA = 255;
 constexpr i16 QB = 64;
-constexpr usize L1_SIZE = 128;
+constexpr usize L1_SIZE = 256;
 constexpr usize VECTOR_SIZE = std::min<usize>(L1_SIZE, util::NATIVE_SIZE<i16>);
 using i16Vec = util::SimdVector<i16, VECTOR_SIZE>;
 


### PR DESCRIPTION
256HL Network
```
Elo   | 113.39 +- 24.75 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 590 W: 306 L: 120 D: 164
Penta | [11, 33, 86, 89, 76]
```
https://furybench.com/test/2016/

bench: 1425319