### PR TITLE
Compute Zobrist lookuptables at compile time

### DIFF
--- a/src/chess/zobrist.hpp
+++ b/src/chess/zobrist.hpp
@@ -15,21 +15,32 @@ using EnPassantTable = std::array<HashKey, 8>;
 
 const auto side_to_move = rng::next_u64();
 
-const auto pieces = [] {
+constexpr u64 murmur3(u64 x) {
+    x ^= x >> 33;
+    x *= 0xff51afd7ed558ccd;
+    x ^= x >> 33;
+    x *= 0xc4ceb9fe1a85ec53;
+    x ^= x >> 33;
+    return x;
+}
+
+constexpr auto pieces = [] {
+    auto next_u64 = [hash = 12477279837831370886ull]() mutable { return hash = murmur3(hash); };
     PieceTable piece_table;
     for (auto &table : piece_table)
         for (auto &color : table)
             for (u64 &square : color)
-                square = rng::next_u64();
+                square = next_u64();
     return piece_table;
 }();
 
-const auto castle_rights = [] {
+constexpr auto castle_rights = [] {
+    auto next_u64 = [hash = 13400036725371814030ull]() mutable { return hash = murmur3(hash); };
     CastleRightsTable castle_rights_table;
-    castle_rights_table[1] = rng::next_u64();
-    castle_rights_table[2] = rng::next_u64();
-    castle_rights_table[4] = rng::next_u64();
-    castle_rights_table[8] = rng::next_u64();
+    castle_rights_table[1] = next_u64();
+    castle_rights_table[2] = next_u64();
+    castle_rights_table[4] = next_u64();
+    castle_rights_table[8] = next_u64();
 
     for (i32 i = 0; i < 16; ++i) {
         if (i == 1 || i == 2 || i == 4 || i == 8) {
@@ -48,10 +59,11 @@ const auto castle_rights = [] {
     return castle_rights_table;
 }();
 
-const auto en_passant = [] {
+constexpr auto en_passant = [] {
+    auto next_u64 = [hash = 2997978520062052832ull]() mutable { return hash = murmur3(hash); };
     EnPassantTable en_passant_table;
     for (u64 &entry : en_passant_table)
-        entry = rng::next_u64();
+        entry = next_u64();
     return en_passant_table;
 }();
 

--- a/src/search/hash.hpp
+++ b/src/search/hash.hpp
@@ -1,0 +1,11 @@
+#ifndef HASH_HPP
+#define HASH_HPP
+
+#include "../util/types.hpp"
+
+struct HashEntry {
+    u64 hash = 0;
+    f64 q = 0.0;
+};
+
+#endif // HASH_HPP


### PR DESCRIPTION
```
Elo   | -0.00 +- 2.75 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 0.05 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 498 W: 163 L: 163 D: 172
Penta | [0, 2, 245, 2, 0]
```
https://furybench.com/test/2066/
bench: 1425319