### PR TITLE
Root PST + New Policy Network

### DIFF
--- a/src/search/game_tree.cpp
+++ b/src/search/game_tree.cpp
@@ -12,7 +12,7 @@
 
 namespace search {
 
-constexpr f32 ROOT_SOFTMAX_TEMPERATURE = 2.0f;
+constexpr f32 ROOT_SOFTMAX_TEMPERATURE = 3.5f;
 constexpr f32 SOFTMAX_TEMPERATURE = 1.0f;
 constexpr f32 ROOT_EXPLORATION_CONSTANT = 1.3f;
 constexpr f32 EXPLORATION_CONSTANT = 1.0f;

--- a/src/search/game_tree.cpp
+++ b/src/search/game_tree.cpp
@@ -12,7 +12,7 @@
 
 namespace search {
 
-constexpr f32 ROOT_SOFTMAX_TEMPERATURE = 3.5f;
+constexpr f32 ROOT_SOFTMAX_TEMPERATURE = 2.0f;
 constexpr f32 SOFTMAX_TEMPERATURE = 1.0f;
 constexpr f32 ROOT_EXPLORATION_CONSTANT = 1.3f;
 constexpr f32 EXPLORATION_CONSTANT = 1.0f;


### PR DESCRIPTION
Second iteration of our policy network showed a sharper policy distribution and was neutral compared to first policy network.
Adding root PST alongside this showed a gain only with the newer network, as it flattens out the policy distributions at root.