### PR TITLE
Bigger value net

### DIFF
--- a/src/eval/value_network.hpp
+++ b/src/eval/value_network.hpp
@@ -10,7 +10,7 @@ namespace network::value {
 
 constexpr i16 QA = 255;
 constexpr i16 QB = 64;
-constexpr usize L1_SIZE = 1024;
+constexpr usize L1_SIZE = 2048;
 constexpr usize VECTOR_SIZE = std::min<usize>(L1_SIZE, util::NATIVE_SIZE<i16>);
 constexpr i16 EVAL_SCALE = 400;
 


### PR DESCRIPTION
```
Elo   | 58.59 +- 14.63 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 5.00]
Games | N: 850 W: 298 L: 156 D: 396
Penta | [7, 55, 183, 149, 31]
```
https://furybench.com/test/3350/